### PR TITLE
Use GitVersion.Tool instead of gitversion.exe which does not work on Mono

### DIFF
--- a/groovy/LfMergeJobs.groovy
+++ b/groovy/LfMergeJobs.groovy
@@ -143,10 +143,10 @@ RUNMODE="PACKAGEBUILD" BUILD=Release . environ
 ${msbuild} /t:RestoreBuildTasks build/LfMerge.proj
 mkdir -p output/Release
 
-if [ -f packages/GitVersion.CommandLine/tools/GitVersion.exe ]; then
-	mono --debug packages/GitVersion.CommandLine/tools/GitVersion.exe -output buildserver
+if [ -f packages/GitVersion.CommandLine/tools/gitversion.exe ]; then
+	mono --debug packages/GitVersion.CommandLine/tools/gitversion.exe -output buildserver
 else
-	mono --debug packages/GitVersion.CommandLine*/tools/GitVersion.exe -output buildserver
+	mono --debug packages/GitVersion.CommandLine*/tools/gitversion.exe -output buildserver
 fi
 
 . gitversion.properties

--- a/groovy/LfMergeJobs.groovy
+++ b/groovy/LfMergeJobs.groovy
@@ -143,11 +143,8 @@ RUNMODE="PACKAGEBUILD" BUILD=Release . environ
 ${msbuild} /t:RestoreBuildTasks build/LfMerge.proj
 mkdir -p output/Release
 
-if [ -f packages/GitVersion.CommandLine/tools/gitversion.exe ]; then
-	mono --debug packages/GitVersion.CommandLine/tools/gitversion.exe -output buildserver
-else
-	mono --debug packages/GitVersion.CommandLine*/tools/gitversion.exe -output buildserver
-fi
+dotnet tool restore
+dotnet gitversion -output buildserver
 
 . gitversion.properties
 

--- a/groovy/utilities/LfMerge.groovy
+++ b/groovy/utilities/LfMerge.groovy
@@ -115,12 +115,8 @@ ${msbuild} /t:RestoreBuildTasks build/LfMerge.proj
 mkdir -p output/Release
 """ +
 '''
-export GIT_BRANCH=$GIT_BRANCH_0
-if [ -f packages/GitVersion.CommandLine/tools/gitversion.exe ]; then
-	mono --debug packages/GitVersion.CommandLine/tools/gitversion.exe -output buildserver
-else
-	mono --debug packages/GitVersion.CommandLine*/tools/gitversion.exe -output buildserver
-fi
+dotnet tool restore
+dotnet gitversion -output buildserver
 
 . gitversion.properties
 

--- a/groovy/utilities/LfMerge.groovy
+++ b/groovy/utilities/LfMerge.groovy
@@ -116,10 +116,10 @@ mkdir -p output/Release
 """ +
 '''
 export GIT_BRANCH=$GIT_BRANCH_0
-if [ -f packages/GitVersion.CommandLine/tools/GitVersion.exe ]; then
-	mono --debug packages/GitVersion.CommandLine/tools/GitVersion.exe -output buildserver
+if [ -f packages/GitVersion.CommandLine/tools/gitversion.exe ]; then
+	mono --debug packages/GitVersion.CommandLine/tools/gitversion.exe -output buildserver
 else
-	mono --debug packages/GitVersion.CommandLine*/tools/GitVersion.exe -output buildserver
+	mono --debug packages/GitVersion.CommandLine*/tools/gitversion.exe -output buildserver
 fi
 
 . gitversion.properties


### PR DESCRIPTION
Looks like the name of the .exe in GitVersion 5.x changed from GitVersion.exe to gitversion.exe at some point, causing build failures on Linux since our build scripts were looking for GitVersion.exe. Update LfMerge build jobs to reflect the new name casing.